### PR TITLE
Fix youtube-dl url

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Multidownload MP3 musics from youtube-dl library!
 ### Download youtube-dl library
 
 ```bash
-sudo wget http://youtube-dl.org/downloads/2013.05.01/youtube-dl -O /usr/bin/youtube-dl
+sudo wget http://youtube-dl.org/downloads/2017.01.05/youtube-dl -O /usr/bin/youtube-dl
 sudo chmod a+x /usr/bin/youtube-dl
 sudo youtube-dl -U
 ```


### PR DESCRIPTION
The url provided for youtube-dl on the tutorial was way too old and didn't work. I replaced it for a newer one.